### PR TITLE
Add setViewport method

### DIFF
--- a/src/Browser/ActionsChain.js
+++ b/src/Browser/ActionsChain.js
@@ -830,6 +830,20 @@ class ActionsChain {
   catch (reject) {
     return this.then(undefined, reject)
   }
+
+  /**
+   * Set Viewport
+   *
+   * @method setViewport
+   *
+   * @param  {Object}   [viewport]
+   *
+   * @chainable
+   */
+  setViewport (viewport) {
+    this._actions.push(() => this._res._page.setViewport(viewport))
+    return this
+  }
 }
 
 module.exports = ActionsChain

--- a/test/unit/response.spec.js
+++ b/test/unit/response.spec.js
@@ -1234,4 +1234,21 @@ test.group('Assertions', (group) => {
     const res = await request.end()
     await res.assertCount('ul li', 3)
   })
+
+  test('assert viewport set correctly', async (assert) => {
+    this.server = http.createServer((req, res) => {
+      res.writeHead(200, { 'content-type': 'text/html' })
+      res.write('Hello world')
+      res.end()
+    }).listen(PORT)
+
+    const Request = RequestManager(BaseRequest, ResponseManager(BaseResponse))
+    const request = new Request(this.browser, BASE_URL, assert)
+    const res = await request.end()
+
+    const viewport = { width: 1200, height: 800 }
+    await res.setViewport(viewport)
+
+    assert.equal(res._page.viewport(), viewport)
+  })
 })


### PR DESCRIPTION
vow-browser has missing function `setViewport`. This function is very useful for testing on responsive page.