### PR TITLE
Prevent error during VowBrowserProvider afterEach call of Browser#close in case where #visit was never called

### DIFF
--- a/src/Browser/index.js
+++ b/src/Browser/index.js
@@ -113,7 +113,9 @@ class Browser {
    * @return {void}
    */
   close () {
-    return this.puppeteerBrowser.close()
+    if (this.puppeteerBrowser) {
+      return this.puppeteerBrowser.close()
+    }
   }
 }
 

--- a/test/unit/browser.spec.js
+++ b/test/unit/browser.spec.js
@@ -60,4 +60,15 @@ test.group('Browser', (group) => {
 
     await browser.close()
   })
+
+  // VowBrowserProvider will call close in the afterEach, but
+  // in the case of an error in the test, that might occur *before*
+  // Browser#visit or Browser#launch.
+  test('its ok to close before launch', async (assert) => {
+    this.server = http.createServer((req, res) => {
+      res.end('done')
+    }).listen(PORT)
+    const browser = new Browser(BaseRequest, BaseResponse, assert)
+    await browser.close()
+  })
 })


### PR DESCRIPTION
VowBrowserProvider will call close in the afterEach, but in the case of an error in the test, that might occur *before* Browser#visit or Browser#launch. In that scenario, Browser#close is throwing an error
because Browser#puppeteerBrowser is null.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/vow-browser/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
